### PR TITLE
[Week 8] Remove traces of AB3 from Jekyll

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: "AB-3"
+title: "ConText"
 theme: minima
 
 header_pages:
@@ -8,7 +8,7 @@ header_pages:
 
 markdown: kramdown
 
-repository: "se-edu/addressbook-level3"
+repository: "AY2324S1-CS2103-W14-3/tp"
 github_icon: "images/github-icon.png"
 
 plugins:


### PR DESCRIPTION
Update website to remove traces of AB-3.

Closes #52.