### PR TITLE
[Week 10] Quick fixes to tidy messages class

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -30,8 +30,8 @@ public class StringUtil {
         requireNonNull(word);
 
         String preppedWord = word.trim();
-        checkArgument(!preppedWord.isEmpty(), Messages.MESSAGE_EMPTY_WORD_PARAMETER);
-        checkArgument(preppedWord.split("\\s+").length == 1, Messages.MESSAGE_SINGLE_WORD_EXPECTED);
+        checkArgument(!preppedWord.isEmpty(), Messages.EMPTY_WORD_PARAMETER);
+        checkArgument(preppedWord.split("\\s+").length == 1, Messages.SINGLE_WORD_EXPECTED);
 
         String preppedSentence = sentence;
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,9 +1,6 @@
 package seedu.address.logic;
 
 
-
-//TODO we could avoid static imports, and instead refer to strings as
-// Messages.FOO. Then we can remove the MESSAGE_ prefix for everything
 //TODO prefix messages containing format specifiers with UNFORMATTED_
 /**
  * Holds message strings used by the logic for display to the user.

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,36 +15,36 @@ package seedu.address.logic;
  * populated by calling their associated methods.
  */
 public final class Messages {
-    public static final String MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX = "The contact index provided is invalid";
-    public static final String MESSAGE_CONTACTS_LISTED_OVERVIEW = "%d contacts listed!";
-    public static final String MESSAGE_DUPLICATE_FIELDS =
+    public static final String INVALID_CONTACT_DISPLAYED_INDEX = "The contact index provided is invalid";
+    public static final String CONTACTS_LISTED_OVERVIEW = "%d contacts listed!";
+    public static final String DUPLICATE_FIELDS =
             "Multiple values specified for the following single-valued field(s): ";
-    public static final String MESSAGE_EMPTY_WORD_PARAMETER = "Word parameter cannot be empty";
-    public static final String MESSAGE_SINGLE_WORD_EXPECTED = "Word parameter should be a single word";
+    public static final String EMPTY_WORD_PARAMETER = "Word parameter cannot be empty";
+    public static final String SINGLE_WORD_EXPECTED = "Word parameter should be a single word";
 
     // Messages associated with various Commands
-    public static final String MESSAGE_ADD_COMMAND_SUCCESS = "New contact added: %1$s";
-    public static final String MESSAGE_COMMAND_DUPLICATE_CONTACT = "This contact is already in your contact list.";
-    public static final String MESSAGE_DELETE_COMMAND_SUCCESS = "Deleted Contact: %1$s";
-    public static final String MESSAGE_EDIT_COMMAND_SUCCESS = "Edited Contact: %1$s";
-    public static final String MESSAGE_EDIT_COMMAND_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_HELP_COMMAND_SHOW_HELP = "Opened help window.";
-    public static final String MESSAGE_LIST_COMMAND_SUCCESS = "Listed all contacts";
+    public static final String ADD_COMMAND_SUCCESS = "New contact added: %1$s";
+    public static final String COMMAND_DUPLICATE_CONTACT = "This contact is already in your contact list.";
+    public static final String DELETE_COMMAND_SUCCESS = "Deleted Contact: %1$s";
+    public static final String EDIT_COMMAND_SUCCESS = "Edited Contact: %1$s";
+    public static final String EDIT_COMMAND_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String HELP_COMMAND_SHOW_HELP = "Opened help window.";
+    public static final String LIST_COMMAND_SUCCESS = "Listed all contacts";
 
     // Exception message
     public static final String FILE_OPS_ERROR_FORMAT = "Could not save data due to the following error: %s";
     public static final String FILE_OPS_PERMISSION_ERROR_FORMAT =
             "Could not save data to file %s due to insufficient permissions to write to the file or the folder.";
-    public static final String MESSAGE_DUPLICATE_CONTACT_EXCEPTION = "Operation would result in duplicate contacts";
+    public static final String DUPLICATE_CONTACT_EXCEPTION = "Operation would result in duplicate contacts";
 
     // Messages associated with Attributes constraints
-    public static final String MESSAGE_NAME_CONSTRAINTS =
+    public static final String NAME_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
-    public static final String MESSAGE_PHONE_CONSTRAINTS =
+    public static final String PHONE_CONSTRAINTS =
             "Phone numbers should only contain numbers, and it should be at least 3 digits long";
 
     // Messages associated with Storage
-    public static final String MESSAGE_FIELD_MISSING = "Contact's %s field is missing.";
+    public static final String FIELD_MISSING = "Contact's %s field is missing.";
 
     //TODO refine the messages above this line
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -50,11 +50,11 @@ public class AddCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         if (model.containsContact(toAdd)) {
-            throw new CommandException(Messages.MESSAGE_COMMAND_DUPLICATE_CONTACT);
+            throw new CommandException(Messages.COMMAND_DUPLICATE_CONTACT);
         }
 
         model.addContact(toAdd);
-        return new CommandResult(String.format(Messages.MESSAGE_ADD_COMMAND_SUCCESS, Contact.format(toAdd)));
+        return new CommandResult(String.format(Messages.ADD_COMMAND_SUCCESS, Contact.format(toAdd)));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -35,12 +35,12 @@ public class DeleteCommand extends Command {
         List<Contact> lastShownList = model.getFilteredContactList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.INVALID_CONTACT_DISPLAYED_INDEX);
         }
 
         Contact contactToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.removeContact(contactToDelete);
-        return new CommandResult(String.format(Messages.MESSAGE_DELETE_COMMAND_SUCCESS,
+        return new CommandResult(String.format(Messages.DELETE_COMMAND_SUCCESS,
                 Contact.format(contactToDelete)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -70,19 +70,19 @@ public class EditCommand extends Command {
         List<Contact> lastShownList = model.getFilteredContactList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.INVALID_CONTACT_DISPLAYED_INDEX);
         }
 
         Contact contactToEdit = lastShownList.get(index.getZeroBased());
         Contact editedContact = createEditedContact(contactToEdit, editContactDescriptor);
 
         if (!contactToEdit.isSameContact(editedContact) && model.containsContact(editedContact)) {
-            throw new CommandException(Messages.MESSAGE_COMMAND_DUPLICATE_CONTACT);
+            throw new CommandException(Messages.COMMAND_DUPLICATE_CONTACT);
         }
 
         model.updateContact(contactToEdit, editedContact);
         model.setContactsFilter(ModelManager.FILTER_NONE);
-        return new CommandResult(String.format(Messages.MESSAGE_EDIT_COMMAND_SUCCESS, Contact.format(editedContact)));
+        return new CommandResult(String.format(Messages.EDIT_COMMAND_SUCCESS, Contact.format(editedContact)));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -33,7 +33,7 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.setContactsFilter(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_CONTACTS_LISTED_OVERVIEW, model.getFilteredContactList().size()));
+                String.format(Messages.CONTACTS_LISTED_OVERVIEW, model.getFilteredContactList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -15,6 +15,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(Messages.MESSAGE_HELP_COMMAND_SHOW_HELP, true, false);
+        return new CommandResult(Messages.HELP_COMMAND_SHOW_HELP, true, false);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -18,6 +18,6 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setContactsFilter(ModelManager.FILTER_NONE);
-        return new CommandResult(Messages.MESSAGE_LIST_COMMAND_SUCCESS);
+        return new CommandResult(Messages.LIST_COMMAND_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -87,7 +87,7 @@ public class ArgumentMultimap {
         Set<String> duplicateFields =
                 Stream.of(duplicatePrefixes).map(Prefix::toString).collect(Collectors.toSet());
 
-        return Messages.MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
+        return Messages.DUPLICATE_FIELDS + String.join(" ", duplicateFields);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -65,7 +65,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editContactDescriptor::setTags);
 
         if (!editContactDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(Messages.MESSAGE_EDIT_COMMAND_NOT_EDITED);
+            throw new ParseException(Messages.EDIT_COMMAND_NOT_EDITED);
         }
 
         return new EditCommand(index, editContactDescriptor);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -46,7 +46,7 @@ public class ParserUtil {
         requireNonNull(name);
         String trimmedName = name.trim();
         if (!Name.isValid(trimmedName)) {
-            throw new ParseException(Messages.MESSAGE_NAME_CONSTRAINTS);
+            throw new ParseException(Messages.NAME_CONSTRAINTS);
         }
         return new Name(trimmedName);
     }
@@ -61,7 +61,7 @@ public class ParserUtil {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
         if (!Phone.isValid(trimmedPhone)) {
-            throw new ParseException(Messages.MESSAGE_PHONE_CONSTRAINTS);
+            throw new ParseException(Messages.PHONE_CONSTRAINTS);
         }
         return new Phone(trimmedPhone);
     }

--- a/src/main/java/seedu/address/model/contact/exceptions/DuplicateContactException.java
+++ b/src/main/java/seedu/address/model/contact/exceptions/DuplicateContactException.java
@@ -8,6 +8,6 @@ import seedu.address.logic.Messages;
  */
 public class DuplicateContactException extends RuntimeException {
     public DuplicateContactException() {
-        super(Messages.MESSAGE_DUPLICATE_CONTACT_EXCEPTION);
+        super(Messages.DUPLICATE_CONTACT_EXCEPTION);
     }
 }

--- a/src/main/java/seedu/address/storage/JsonContact.java
+++ b/src/main/java/seedu/address/storage/JsonContact.java
@@ -80,23 +80,23 @@ class JsonContact {
         }
 
         if (name == null) {
-            throw new IllegalValueException(String.format(Messages.MESSAGE_FIELD_MISSING, Name.class.getSimpleName()));
+            throw new IllegalValueException(String.format(Messages.FIELD_MISSING, Name.class.getSimpleName()));
         }
         if (!Name.isValid(name)) {
-            throw new IllegalValueException(Messages.MESSAGE_NAME_CONSTRAINTS);
+            throw new IllegalValueException(Messages.NAME_CONSTRAINTS);
         }
         final Name modelName = new Name(name);
 
         if (phone == null) {
-            throw new IllegalValueException(String.format(Messages.MESSAGE_FIELD_MISSING, Phone.class.getSimpleName()));
+            throw new IllegalValueException(String.format(Messages.FIELD_MISSING, Phone.class.getSimpleName()));
         }
         if (!Phone.isValid(phone)) {
-            throw new IllegalValueException(Messages.MESSAGE_PHONE_CONSTRAINTS);
+            throw new IllegalValueException(Messages.PHONE_CONSTRAINTS);
         }
         final Phone modelPhone = new Phone(phone);
 
         if (email == null) {
-            throw new IllegalValueException(String.format(Messages.MESSAGE_FIELD_MISSING, Email.class.getSimpleName()));
+            throw new IllegalValueException(String.format(Messages.FIELD_MISSING, Email.class.getSimpleName()));
         }
         if (!Email.isValid(email)) {
             throw new IllegalValueException(Messages.EMAIL_INVALID);
@@ -104,7 +104,7 @@ class JsonContact {
         final Email modelEmail = new Email(email);
 
         if (this.note == null) {
-            throw new IllegalValueException(String.format(Messages.MESSAGE_FIELD_MISSING, Note.class.getSimpleName()));
+            throw new IllegalValueException(String.format(Messages.FIELD_MISSING, Note.class.getSimpleName()));
         }
         final Note modelNote = new Note(this.note);
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,8 +1,6 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.logic.Messages.COMMAND_UNKNOWN;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TestData.Valid.EMAIL_DESC_AMY;
 import static seedu.address.testutil.TestData.Valid.NAME_DESC_AMY;
@@ -55,19 +53,19 @@ public class LogicManagerTest {
     @Test
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
-        assertParseException(invalidCommand, COMMAND_UNKNOWN);
+        assertParseException(invalidCommand, Messages.COMMAND_UNKNOWN);
     }
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+        assertCommandException(deleteCommand, Messages.INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     @Test
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, Messages.MESSAGE_LIST_COMMAND_SUCCESS, model);
+        assertCommandSuccess(listCommand, Messages.LIST_COMMAND_SUCCESS, model);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -34,7 +34,7 @@ public class AddCommandIntegrationTest {
         expectedModel.addContact(validContact);
 
         assertCommandSuccess(new AddCommand(validContact), model,
-                String.format(Messages.MESSAGE_ADD_COMMAND_SUCCESS, Contact.format(validContact)),
+                String.format(Messages.ADD_COMMAND_SUCCESS, Contact.format(validContact)),
                 expectedModel);
     }
 
@@ -42,7 +42,7 @@ public class AddCommandIntegrationTest {
     public void execute_duplicateContact_throwsCommandException() {
         Contact contactInList = model.getContacts().getUnmodifiableList().get(0);
         assertCommandFailure(new AddCommand(contactInList), model,
-                Messages.MESSAGE_COMMAND_DUPLICATE_CONTACT);
+                Messages.COMMAND_DUPLICATE_CONTACT);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -37,7 +37,7 @@ public class AddCommandTest {
 
         CommandResult commandResult = new AddCommand(validContact).execute(modelStub);
 
-        assertEquals(String.format(Messages.MESSAGE_ADD_COMMAND_SUCCESS, Contact.format(validContact)),
+        assertEquals(String.format(Messages.ADD_COMMAND_SUCCESS, Contact.format(validContact)),
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validContact), modelStub.contactsAdded);
     }
@@ -49,7 +49,7 @@ public class AddCommandTest {
         ModelStub modelStub = new ModelStubWithContact(validContact);
 
         assertThrows(CommandException.class,
-                Messages.MESSAGE_COMMAND_DUPLICATE_CONTACT, () -> addCommand.execute(modelStub));
+                Messages.COMMAND_DUPLICATE_CONTACT, () -> addCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -32,7 +32,7 @@ public class DeleteCommandTest {
         Contact contactToDelete = model.getFilteredContactList().get(FIRST_CONTACT.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(FIRST_CONTACT);
 
-        String expectedMessage = String.format(Messages.MESSAGE_DELETE_COMMAND_SUCCESS,
+        String expectedMessage = String.format(Messages.DELETE_COMMAND_SUCCESS,
                 Contact.format(contactToDelete));
 
         ModelManager expectedModel = new ModelManager(model.getContacts(), new Settings());
@@ -46,7 +46,7 @@ public class DeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredContactList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     @Test
@@ -56,7 +56,7 @@ public class DeleteCommandTest {
         Contact contactToDelete = model.getFilteredContactList().get(FIRST_CONTACT.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(FIRST_CONTACT);
 
-        String expectedMessage = String.format(Messages.MESSAGE_DELETE_COMMAND_SUCCESS,
+        String expectedMessage = String.format(Messages.DELETE_COMMAND_SUCCESS,
                 Contact.format(contactToDelete));
 
         Model expectedModel = new ModelManager(model.getContacts(), new Settings());
@@ -76,7 +76,7 @@ public class DeleteCommandTest {
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -39,7 +39,7 @@ public class EditCommandTest {
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder(editedContact).build();
         EditCommand editCommand = new EditCommand(FIRST_CONTACT, descriptor);
 
-        String expectedMessage = String.format(Messages.MESSAGE_EDIT_COMMAND_SUCCESS, Contact.format(editedContact));
+        String expectedMessage = String.format(Messages.EDIT_COMMAND_SUCCESS, Contact.format(editedContact));
 
         Model expectedModel = new ModelManager(new Contacts(model.getContacts()), new Settings());
         expectedModel.updateContact(model.getFilteredContactList().get(0), editedContact);
@@ -60,7 +60,7 @@ public class EditCommandTest {
                 .withPhone(PHONE_BOB).withTags(TestData.Valid.Tag.ALPHANUMERIC_SPACES).build();
         EditCommand editCommand = new EditCommand(indexLastContact, descriptor);
 
-        String expectedMessage = String.format(Messages.MESSAGE_EDIT_COMMAND_SUCCESS, Contact.format(editedContact));
+        String expectedMessage = String.format(Messages.EDIT_COMMAND_SUCCESS, Contact.format(editedContact));
 
         Model expectedModel = new ModelManager(new Contacts(model.getContacts()), new Settings());
         expectedModel.updateContact(lastContact, editedContact);
@@ -73,7 +73,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(FIRST_CONTACT, new EditContactDescriptor());
         Contact editedContact = model.getFilteredContactList().get(FIRST_CONTACT.getZeroBased());
 
-        String expectedMessage = String.format(Messages.MESSAGE_EDIT_COMMAND_SUCCESS, Contact.format(editedContact));
+        String expectedMessage = String.format(Messages.EDIT_COMMAND_SUCCESS, Contact.format(editedContact));
 
         Model expectedModel = new ModelManager(new Contacts(model.getContacts()), new Settings());
 
@@ -89,7 +89,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(FIRST_CONTACT,
                 new EditContactDescriptorBuilder().withName(NAME_BOB).build());
 
-        String expectedMessage = String.format(Messages.MESSAGE_EDIT_COMMAND_SUCCESS, Contact.format(editedContact));
+        String expectedMessage = String.format(Messages.EDIT_COMMAND_SUCCESS, Contact.format(editedContact));
 
         Model expectedModel = new ModelManager(new Contacts(model.getContacts()), new Settings());
         expectedModel.updateContact(model.getFilteredContactList().get(0), editedContact);
@@ -103,7 +103,7 @@ public class EditCommandTest {
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder(firstContact).build();
         EditCommand editCommand = new EditCommand(SECOND_CONTACT, descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_COMMAND_DUPLICATE_CONTACT);
+        assertCommandFailure(editCommand, model, Messages.COMMAND_DUPLICATE_CONTACT);
     }
 
     @Test
@@ -115,7 +115,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(FIRST_CONTACT,
                 new EditContactDescriptorBuilder(contactInList).build());
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_COMMAND_DUPLICATE_CONTACT);
+        assertCommandFailure(editCommand, model, Messages.COMMAND_DUPLICATE_CONTACT);
     }
 
     @Test
@@ -124,7 +124,7 @@ public class EditCommandTest {
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withName(NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     /**
@@ -141,7 +141,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
                 new EditContactDescriptorBuilder().withName(NAME_BOB).build());
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.Messages.MESSAGE_CONTACTS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TestData.Valid.Contact.CARL;
 import static seedu.address.testutil.TestData.Valid.Contact.ELLE;
@@ -15,6 +14,7 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.Settings;
@@ -56,7 +56,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noContactFound() {
-        String expectedMessage = String.format(MESSAGE_CONTACTS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(Messages.CONTACTS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.setContactsFilter(predicate);
@@ -66,7 +66,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multipleContactsFound() {
-        String expectedMessage = String.format(MESSAGE_CONTACTS_LISTED_OVERVIEW, 3);
+        String expectedMessage = String.format(Messages.CONTACTS_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.setContactsFilter(predicate);

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(Messages.MESSAGE_HELP_COMMAND_SHOW_HELP, true, false);
+        CommandResult expectedCommandResult = new CommandResult(Messages.HELP_COMMAND_SHOW_HELP, true, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -29,12 +29,12 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, Messages.MESSAGE_LIST_COMMAND_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), model, Messages.LIST_COMMAND_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showContactAtIndex(model, FIRST_CONTACT);
-        assertCommandSuccess(new ListCommand(), model, Messages.MESSAGE_LIST_COMMAND_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), model, Messages.LIST_COMMAND_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -153,11 +153,11 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + NOTE_DESC_BOB
-                + TestData.Valid.Tag.FLAG_ALPHANUMERIC, Messages.MESSAGE_NAME_CONSTRAINTS);
+                + TestData.Valid.Tag.FLAG_ALPHANUMERIC, Messages.NAME_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC + EMAIL_DESC_BOB + NOTE_DESC_BOB
-                + TestData.Valid.Tag.FLAG_ALPHANUMERIC, Messages.MESSAGE_PHONE_CONSTRAINTS);
+                + TestData.Valid.Tag.FLAG_ALPHANUMERIC, Messages.PHONE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC + NOTE_DESC_BOB
@@ -176,7 +176,7 @@ public class AddCommandParserTest {
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, NAME_DESC + PHONE_DESC + EMAIL_DESC_BOB + NOTE_DESC_BOB,
-                Messages.MESSAGE_NAME_CONSTRAINTS);
+                Messages.NAME_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, TestData.EXTRA_WORDS + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -45,7 +45,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, NAME_AMY, MESSAGE_INVALID_FORMAT);
 
         // no field specified
-        assertParseFailure(parser, "1", Messages.MESSAGE_EDIT_COMMAND_NOT_EDITED);
+        assertParseFailure(parser, "1", Messages.EDIT_COMMAND_NOT_EDITED);
 
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
@@ -68,8 +68,8 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + NAME_DESC, Messages.MESSAGE_NAME_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, "1" + PHONE_DESC, Messages.MESSAGE_PHONE_CONSTRAINTS); // invalid phone
+        assertParseFailure(parser, "1" + NAME_DESC, Messages.NAME_CONSTRAINTS); // invalid name
+        assertParseFailure(parser, "1" + PHONE_DESC, Messages.PHONE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + EMAIL_DESC, Messages.EMAIL_INVALID); // invalid email
         // Invalid tag
         assertParseFailure(
@@ -79,7 +79,7 @@ public class EditCommandParserTest {
         );
 
         // invalid phone followed by valid email
-        assertParseFailure(parser, "1" + PHONE_DESC + EMAIL_DESC_AMY, Messages.MESSAGE_PHONE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + PHONE_DESC + EMAIL_DESC_AMY, Messages.PHONE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Contact} being edited,
         // parsing it together with a valid tag results in error
@@ -110,7 +110,7 @@ public class EditCommandParserTest {
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + NAME_DESC + EMAIL_DESC + NOTE_AMY + PHONE_AMY,
-                Messages.MESSAGE_NAME_CONSTRAINTS);
+                Messages.NAME_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/InputParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/InputParserTest.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.Messages.COMMAND_UNKNOWN;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TestData.IndexContact.FIRST_CONTACT;
 
@@ -99,7 +98,7 @@ public class InputParserTest {
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(
             ParseException.class,
-            COMMAND_UNKNOWN,
+            Messages.COMMAND_UNKNOWN,
             () -> InputParser.parseCommand("unknownCommand")
         );
     }

--- a/src/test/java/seedu/address/storage/JsonContactTest.java
+++ b/src/test/java/seedu/address/storage/JsonContactTest.java
@@ -38,14 +38,14 @@ public class JsonContactTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonContact contact =
                 new JsonContact(TestData.Invalid.NAME, VALID_PHONE, VALID_EMAIL, VALID_NOTE, VALID_TAGS);
-        String expectedMessage = Messages.MESSAGE_NAME_CONSTRAINTS;
+        String expectedMessage = Messages.NAME_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, contact::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonContact contact = new JsonContact(null, VALID_PHONE, VALID_EMAIL, VALID_NOTE, VALID_TAGS);
-        String expectedMessage = String.format(Messages.MESSAGE_FIELD_MISSING, Name.class.getSimpleName());
+        String expectedMessage = String.format(Messages.FIELD_MISSING, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, contact::toModelType);
     }
 
@@ -53,14 +53,14 @@ public class JsonContactTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonContact contact =
                 new JsonContact(VALID_NAME, TestData.Invalid.PHONE, VALID_EMAIL, VALID_NOTE, VALID_TAGS);
-        String expectedMessage = Messages.MESSAGE_PHONE_CONSTRAINTS;
+        String expectedMessage = Messages.PHONE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, contact::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonContact contact = new JsonContact(VALID_NAME, null, VALID_EMAIL, VALID_NOTE, VALID_TAGS);
-        String expectedMessage = String.format(Messages.MESSAGE_FIELD_MISSING, Phone.class.getSimpleName());
+        String expectedMessage = String.format(Messages.FIELD_MISSING, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, contact::toModelType);
     }
 
@@ -75,14 +75,14 @@ public class JsonContactTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonContact contact = new JsonContact(VALID_NAME, VALID_PHONE, null, VALID_NOTE, VALID_TAGS);
-        String expectedMessage = String.format(Messages.MESSAGE_FIELD_MISSING, Email.class.getSimpleName());
+        String expectedMessage = String.format(Messages.FIELD_MISSING, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, contact::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonContact contact = new JsonContact(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
-        String expectedMessage = String.format(Messages.MESSAGE_FIELD_MISSING, Note.class.getSimpleName());
+        String expectedMessage = String.format(Messages.FIELD_MISSING, Note.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, contact::toModelType);
     }
 


### PR DESCRIPTION
Since this class may be used for development of new features, I have made some quick fixings regarding:
- scrapping all the ```MESSAGES```_ prefix for naming
- remove all static imports
There is still some more work to do to address issue #94. I think we can merge this PR first, and we can do another review after we are done with new features