### PR TITLE
Fix \data error when JAR run in a separate directory

### DIFF
--- a/src/main/java/swe/context/commons/util/FileUtil.java
+++ b/src/main/java/swe/context/commons/util/FileUtil.java
@@ -14,6 +14,10 @@ import java.nio.file.Paths;
 public class FileUtil {
     private static final String CHARSET = "UTF-8";
 
+    public static boolean isFileExists(Path file) {
+        return Files.exists(file) && Files.isRegularFile(file);
+    }
+
     /**
      * Assumes file exists
      */
@@ -27,6 +31,40 @@ public class FileUtil {
      */
     public static void writeToFile(Path file, String content) throws IOException {
         Files.write(file, content.getBytes(CHARSET));
+    }
+
+    /**
+     * Creates a file if it does not exist along with its missing parent directories.
+     * @throws IOException if the file or directory cannot be created.
+     */
+    public static void createIfMissing(Path file) throws IOException {
+        if (!isFileExists(file)) {
+            createFile(file);
+        }
+    }
+
+    /**
+     * Creates a file if it does not exist along with its missing parent directories.
+     */
+    public static void createFile(Path file) throws IOException {
+        if (Files.exists(file)) {
+            return;
+        }
+
+        createParentDirsOfFile(file);
+
+        Files.createFile(file);
+    }
+
+    /**
+     * Creates parent directories of file if it has a parent directory
+     */
+    public static void createParentDirsOfFile(Path file) throws IOException {
+        Path parentDir = file.getParent();
+
+        if (parentDir != null) {
+            Files.createDirectories(parentDir);
+        }
     }
 
     /**

--- a/src/main/java/swe/context/storage/JsonContactsStorage.java
+++ b/src/main/java/swe/context/storage/JsonContactsStorage.java
@@ -8,6 +8,7 @@ import java.util.logging.Logger;
 import swe.context.commons.core.LogsCenter;
 import swe.context.commons.exceptions.DataLoadingException;
 import swe.context.commons.exceptions.IllegalValueException;
+import swe.context.commons.util.FileUtil;
 import swe.context.commons.util.JsonUtil;
 import swe.context.commons.util.StringUtil;
 import swe.context.model.Contacts;
@@ -63,6 +64,7 @@ public class JsonContactsStorage implements ContactsStorage {
 
     @Override
     public void saveContacts(ReadOnlyContacts contacts) throws IOException {
+        FileUtil.createIfMissing(path);
         JsonUtil.saveJsonFile(new JsonContacts(contacts), this.path);
     }
 }


### PR DESCRIPTION
Previous commits might have remove FileUtil directory creating methods which result in this bug to occur.

Fixes #116 .
