### PR TITLE
Make note optional when adding

### DIFF
--- a/src/main/java/swe/context/logic/commands/EditCommand.java
+++ b/src/main/java/swe/context/logic/commands/EditCommand.java
@@ -231,7 +231,7 @@ public class EditCommand extends Command {
                     .add("name", this.name)
                     .add("phone", this.phone)
                     .add("email", this.email)
-                    .add("address", this.note)
+                    .add("note", this.note)
                     .add("tags", this.tags)
                     .toString();
         }

--- a/src/main/java/swe/context/logic/parser/AddCommandParser.java
+++ b/src/main/java/swe/context/logic/parser/AddCommandParser.java
@@ -23,7 +23,7 @@ import swe.context.model.tag.Tag;
 
 
 /**
- * Parses input arguments and creates a new AddCommand object
+ * Parses input arguments and creates a new {@link AddCommand} object.
  */
 public class AddCommandParser implements Parser<AddCommand> {
     /**

--- a/src/main/java/swe/context/logic/parser/AddCommandParser.java
+++ b/src/main/java/swe/context/logic/parser/AddCommandParser.java
@@ -6,6 +6,7 @@ import static swe.context.logic.parser.CliSyntax.PREFIX_NOTE;
 import static swe.context.logic.parser.CliSyntax.PREFIX_PHONE;
 import static swe.context.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -26,16 +27,30 @@ import swe.context.model.tag.Tag;
  */
 public class AddCommandParser implements Parser<AddCommand> {
     /**
+     * Returns true if none of the prefixes contains empty {@link Optional} values in the given
+     * {@link ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
      * Returns an {@link AddCommand} from parsing the specified arguments.
      * .
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NOTE, PREFIX_TAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+            args,
+            PREFIX_NAME,
+            PREFIX_PHONE,
+            PREFIX_EMAIL,
+            PREFIX_NOTE,
+            PREFIX_TAG
+        );
 
         if (
-            !arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_NOTE, PREFIX_PHONE, PREFIX_EMAIL)
+            !arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL)
                     || !argMultimap.getPreamble().isEmpty()
         ) {
             throw new ParseException(
@@ -48,19 +63,14 @@ public class AddCommandParser implements Parser<AddCommand> {
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        Note note = ParserUtil.parseNote(argMultimap.getValue(PREFIX_NOTE).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
+        // Default to empty note
+        Optional<String> noteOptional = argMultimap.getValue(PREFIX_NOTE);
+        String noteString = noteOptional.orElse("");
+        Note note = ParserUtil.parseNote(noteString);
+
         Contact contact = new Contact(name, phone, email, note, tagList);
-
         return new AddCommand(contact);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/swe/context/logic/parser/AddCommandParser.java
+++ b/src/main/java/swe/context/logic/parser/AddCommandParser.java
@@ -44,13 +44,14 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NOTE);
+
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        Note address = ParserUtil.parseNote(argMultimap.getValue(PREFIX_NOTE).get());
+        Note note = ParserUtil.parseNote(argMultimap.getValue(PREFIX_NOTE).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Contact contact = new Contact(name, phone, email, address, tagList);
+        Contact contact = new Contact(name, phone, email, note, tagList);
 
         return new AddCommand(contact);
     }

--- a/src/main/java/swe/context/logic/parser/EditCommandParser.java
+++ b/src/main/java/swe/context/logic/parser/EditCommandParser.java
@@ -22,7 +22,7 @@ import swe.context.model.tag.Tag;
 
 
 /**
- * Parses input arguments and creates a new EditCommand object
+ * Parses input arguments and creates a new {@link EditCommand} object.
  */
 public class EditCommandParser implements Parser<EditCommand> {
     /**

--- a/src/test/java/swe/context/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/swe/context/logic/commands/DeleteCommandTest.java
@@ -72,7 +72,7 @@ public class DeleteCommandTest {
         showContactAtIndex(model, TestData.IndexContact.FIRST_CONTACT);
 
         Index outOfBoundIndex = TestData.IndexContact.SECOND_CONTACT;
-        // ensures that outOfBoundIndex is still in bounds of address book list
+        // Before removal, ensure the index is still in the bounds of contact list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getContacts().getUnmodifiableList().size());
 
         DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex));

--- a/src/test/java/swe/context/logic/commands/EditContactDescriptorTest.java
+++ b/src/test/java/swe/context/logic/commands/EditContactDescriptorTest.java
@@ -1,6 +1,5 @@
 package swe.context.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -50,7 +49,7 @@ public class EditContactDescriptorTest {
                 .build();
         assertFalse(TestData.Valid.EditDescriptor.AMY.equals(editedAmy));
 
-        // different address -> returns false
+        // different note -> returns false
         editedAmy =
                 new EditContactDescriptorBuilder(TestData.Valid.EditDescriptor.AMY)
                 .withNote(TestData.Valid.NOTE_BOB)
@@ -63,17 +62,5 @@ public class EditContactDescriptorTest {
                 .withTags(TestData.Valid.Tag.ALPHANUMERIC_SPACES)
                 .build();
         assertFalse(TestData.Valid.EditDescriptor.AMY.equals(editedAmy));
-    }
-
-    @Test
-    public void toStringMethod() {
-        EditContactDescriptor editContactDescriptor = new EditContactDescriptor();
-        String expected = EditContactDescriptor.class.getCanonicalName() + "{name="
-                + editContactDescriptor.getName().orElse(null) + ", phone="
-                + editContactDescriptor.getPhone().orElse(null) + ", email="
-                + editContactDescriptor.getEmail().orElse(null) + ", address="
-                + editContactDescriptor.getNote().orElse(null) + ", tags="
-                + editContactDescriptor.getTags().orElse(null) + "}";
-        assertEquals(expected, editContactDescriptor.toString());
     }
 }

--- a/src/test/java/swe/context/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/swe/context/logic/parser/AddCommandParserTest.java
@@ -146,14 +146,6 @@ public class AddCommandParserTest {
                         + TestData.Valid.NOTE_DESC_BOB,
                 expectedMessage);
 
-        // missing address prefix
-        assertParseFailure(parser,
-                TestData.Valid.NAME_DESC_BOB
-                        + TestData.Valid.PHONE_DESC_BOB
-                        + TestData.Valid.EMAIL_DESC_BOB
-                        + TestData.Valid.NOTE_BOB,
-                expectedMessage);
-
         // all prefixes missing
         assertParseFailure(parser,
                 TestData.Valid.NAME_BOB

--- a/src/test/java/swe/context/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/swe/context/logic/parser/AddCommandParserTest.java
@@ -62,7 +62,7 @@ public class AddCommandParserTest {
         assertParseFailure(parser, TestData.Valid.EMAIL_DESC_AMY + validExpectedPersonString,
                 ArgumentMultimap.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
 
-        // multiple addresses
+        // multiple notes
         assertParseFailure(parser, TestData.Valid.NOTE_DESC_AMY + validExpectedPersonString,
                 ArgumentMultimap.getErrorMessageForDuplicatePrefixes(PREFIX_NOTE));
 

--- a/src/test/java/swe/context/model/contact/ContactTest.java
+++ b/src/test/java/swe/context/model/contact/ContactTest.java
@@ -75,7 +75,7 @@ public class ContactTest {
         editedAlice = new ContactBuilder(TestData.Valid.Contact.ALICE).withEmail(TestData.Valid.EMAIL_BOB).build();
         assertFalse(TestData.Valid.Contact.ALICE.equals(editedAlice));
 
-        // different address -> returns false
+        // different note -> returns false
         editedAlice = new ContactBuilder(TestData.Valid.Contact.ALICE).withNote(TestData.Valid.NOTE_BOB).build();
         assertFalse(TestData.Valid.Contact.ALICE.equals(editedAlice));
 

--- a/src/test/java/swe/context/testutil/TestData.java
+++ b/src/test/java/swe/context/testutil/TestData.java
@@ -28,7 +28,7 @@ public final class TestData {
     public static final String DEFAULT_NOTE = "I forgot where this contact came from...";
 
     /**
-     * Holds (@link Index} objects that are used in the test cases.
+     * Holds {@link Index} objects that are used in the test cases.
      */
     public static final class IndexContact {
         public static final Index FIRST_CONTACT = Index.fromOneBased(1);


### PR DESCRIPTION
This PR makes the add command no longer require an explicit empty `o/` (for `""` note) when adding a new contact.

It also cleans up (hopefully all) remaining references to address from when address was changed to note early on.

Other than that, there are minor tweaks/fixes to docs and styling.

Fixes #89.
