### PR TITLE
Relax input validation checks

### DIFF
--- a/src/main/java/swe/context/logic/Messages.java
+++ b/src/main/java/swe/context/logic/Messages.java
@@ -35,12 +35,6 @@ public final class Messages {
             "Could not save data to file %s due to insufficient permissions to write to the file or the folder.";
     public static final String DUPLICATE_CONTACT_EXCEPTION = "Operation would result in duplicate contacts";
 
-    // Messages associated with Attributes constraints
-    public static final String NAME_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
-    public static final String PHONE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-
     // Messages associated with Storage
     public static final String FIELD_MISSING = "Contact's %s field is missing.";
 
@@ -56,11 +50,15 @@ public final class Messages {
     public static final String COMMAND_EXIT_SUCCESS = "Exiting app...";
 
     // Contacts
-    private static final String UNFORMATTED_TAG_INVALID =
-            "\"%s\" is not a valid tag. Tags must be alphanumeric (spaces allowed).";
-
+    // Messages associated with Attributes constraints
+    public static final String NAME_INVALID =
+            "Names must be alphanumeric (spaces allowed).";
+    public static final String PHONE_INVALID =
+            "Phone numbers must start with at least 3 digits.";
     public static final String EMAIL_INVALID =
             "Emails must roughly be of the form \"example_email@foo-domain.sg.\"";
+    private static final String UNFORMATTED_TAG_INVALID =
+            "\"%s\" is not a valid tag. Tags must be alphanumeric (spaces allowed).";
 
     // JSON
     public static final String CONVERT_CONTACTS_DUPLICATE = "Encountered duplicate while converting contacts.";

--- a/src/main/java/swe/context/logic/parser/ParserUtil.java
+++ b/src/main/java/swe/context/logic/parser/ParserUtil.java
@@ -46,7 +46,7 @@ public class ParserUtil {
         requireNonNull(name);
         String trimmedName = name.trim();
         if (!Name.isValid(trimmedName)) {
-            throw new ParseException(Messages.NAME_CONSTRAINTS);
+            throw new ParseException(Messages.NAME_INVALID);
         }
         return new Name(trimmedName);
     }
@@ -61,7 +61,7 @@ public class ParserUtil {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
         if (!Phone.isValid(trimmedPhone)) {
-            throw new ParseException(Messages.PHONE_CONSTRAINTS);
+            throw new ParseException(Messages.PHONE_INVALID);
         }
         return new Phone(trimmedPhone);
     }

--- a/src/main/java/swe/context/model/contact/Email.java
+++ b/src/main/java/swe/context/model/contact/Email.java
@@ -9,19 +9,20 @@ package swe.context.model.contact;
  * {@link #isValid(String)}.
  */
 public class Email {
+    /*
+     * Requires a form similar to example_email@foo-domain.sg.
+     */
+    public static final String REGEX_VALID = "^[a-zA-Z\\d]+(?:[+_.-][a-zA-Z\\d]+)*"
+            + "@(?:[a-zA-Z\\d]+(?:-[a-zA-Z\\d]+)*\\.)+"
+            + "[a-zA-Z\\d]+(?:-[a-zA-Z\\d]+)*$";
+
     public final String value;
 
     /**
      * Returns whether the specified value is valid.
-     *
-     * Emails must roughly be of the form example_email@foo-domain.sg.
      */
     public static boolean isValid(String value) {
-        return value.matches(
-            "^[a-zA-Z\\d]+(?:[+_.-][a-zA-Z\\d]+)*"
-                    + "@(?:[a-zA-Z\\d]+(?:-[a-zA-Z\\d]+)*\\.)+"
-                    + "(?:[a-zA-Z\\d]+(?:-[a-zA-Z\\d]+)*){2,}$"
-        );
+        return value.matches(Email.REGEX_VALID);
     }
 
     /**

--- a/src/main/java/swe/context/model/contact/Name.java
+++ b/src/main/java/swe/context/model/contact/Name.java
@@ -13,7 +13,7 @@ public class Name {
      * Disallows a space as the first character. This prevents " " from being
      * valid.
      */
-    public static final String REGEX_VALID = "[a-zA-Z\\d][a-zA-Z\\d ]*";
+    public static final String REGEX_VALID = "^[a-zA-Z\\d][a-zA-Z\\d ]*$";
 
     public final String value;
 
@@ -23,7 +23,7 @@ public class Name {
      * Names must be an alphanumeric and may contain spaces, but cannot start with a space.
      */
     public static boolean isValid(String value) {
-        return value.matches(REGEX_VALID);
+        return value.matches(Name.REGEX_VALID);
     }
 
     /**

--- a/src/main/java/swe/context/model/contact/Phone.java
+++ b/src/main/java/swe/context/model/contact/Phone.java
@@ -12,7 +12,7 @@ public class Phone {
     /*
      * Requires starting with at least 3 of digits.
      */
-    public static final String REGEX_VALID = "^\\d{3,}";
+    public static final String REGEX_VALID = "^\\d{3,}.*$";
 
     public final String value;
 

--- a/src/main/java/swe/context/model/contact/Phone.java
+++ b/src/main/java/swe/context/model/contact/Phone.java
@@ -9,13 +9,18 @@ package swe.context.model.contact;
  * {@link #isValid(String)}.
  */
 public class Phone {
+    /*
+     * Requires starting with at least 3 of digits.
+     */
+    public static final String REGEX_VALID = "^\\d{3,}";
+
     public final String value;
 
     /**
      * Returns true if a given string is a valid phone number.
      */
     public static boolean isValid(String value) {
-        return value.matches("\\d{3,}");
+        return value.matches(Phone.REGEX_VALID);
     }
 
     /**

--- a/src/main/java/swe/context/storage/JsonContact.java
+++ b/src/main/java/swe/context/storage/JsonContact.java
@@ -83,7 +83,7 @@ class JsonContact {
             throw new IllegalValueException(String.format(Messages.FIELD_MISSING, Name.class.getSimpleName()));
         }
         if (!Name.isValid(name)) {
-            throw new IllegalValueException(Messages.NAME_CONSTRAINTS);
+            throw new IllegalValueException(Messages.NAME_INVALID);
         }
         final Name modelName = new Name(name);
 
@@ -91,7 +91,7 @@ class JsonContact {
             throw new IllegalValueException(String.format(Messages.FIELD_MISSING, Phone.class.getSimpleName()));
         }
         if (!Phone.isValid(phone)) {
-            throw new IllegalValueException(Messages.PHONE_CONSTRAINTS);
+            throw new IllegalValueException(Messages.PHONE_INVALID);
         }
         final Phone modelPhone = new Phone(phone);
 

--- a/src/test/java/swe/context/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/swe/context/logic/parser/AddCommandParserTest.java
@@ -172,7 +172,7 @@ public class AddCommandParserTest {
                         + TestData.Valid.EMAIL_DESC_BOB
                         + TestData.Valid.NOTE_DESC_BOB
                         + TestData.Valid.Tag.FLAG_ALPHANUMERIC,
-                Messages.NAME_CONSTRAINTS);
+                Messages.NAME_INVALID);
 
         // invalid phone
         assertParseFailure(parser,
@@ -181,7 +181,7 @@ public class AddCommandParserTest {
                         + TestData.Valid.EMAIL_DESC_BOB
                         + TestData.Valid.NOTE_DESC_BOB
                         + TestData.Valid.Tag.FLAG_ALPHANUMERIC,
-                Messages.PHONE_CONSTRAINTS);
+                Messages.PHONE_INVALID);
 
         // invalid email
         assertParseFailure(parser,
@@ -209,7 +209,7 @@ public class AddCommandParserTest {
                         + TestData.Invalid.PHONE_DESC
                         + TestData.Valid.EMAIL_DESC_BOB
                         + TestData.Valid.NOTE_DESC_BOB,
-                Messages.NAME_CONSTRAINTS);
+                Messages.NAME_INVALID);
 
         // non-empty preamble
         assertParseFailure(parser,

--- a/src/test/java/swe/context/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/swe/context/logic/parser/EditCommandParserTest.java
@@ -51,9 +51,9 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
-        assertParseFailure(parser, "1" + TestData.Invalid.NAME_DESC, Messages.NAME_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TestData.Invalid.NAME_DESC, Messages.NAME_INVALID);
         // invalid phone
-        assertParseFailure(parser, "1" + TestData.Invalid.PHONE_DESC, Messages.PHONE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TestData.Invalid.PHONE_DESC, Messages.PHONE_INVALID);
         // invalid email
         assertParseFailure(parser, "1" + TestData.Invalid.EMAIL_DESC, Messages.EMAIL_INVALID);
         // Invalid tag
@@ -68,7 +68,7 @@ public class EditCommandParserTest {
                 "1"
                         + TestData.Invalid.PHONE_DESC
                         + TestData.Valid.EMAIL_DESC_AMY,
-                Messages.PHONE_CONSTRAINTS);
+                Messages.PHONE_INVALID);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Contact} being edited,
         // parsing it together with a valid tag results in error
@@ -104,7 +104,7 @@ public class EditCommandParserTest {
                         + TestData.Invalid.EMAIL_DESC
                         + TestData.Valid.NOTE_AMY
                         + TestData.Valid.PHONE_AMY,
-                Messages.NAME_CONSTRAINTS);
+                Messages.NAME_INVALID);
     }
 
     @Test

--- a/src/test/java/swe/context/model/contact/EmailTest.java
+++ b/src/test/java/swe/context/model/contact/EmailTest.java
@@ -36,7 +36,6 @@ public class EmailTest {
         assertFalse(Email.isValid("peterjack@example.com.")); // domain name ends with a period
         assertFalse(Email.isValid("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValid("peterjack@example.com-")); // domain name ends with a hyphen
-        assertFalse(Email.isValid("peterjack@example.c")); // top level domain has less than two chars
 
         // valid email
         assertTrue(Email.isValid("PeterJack_1190@example.com")); // underscore in local part
@@ -47,5 +46,6 @@ public class EmailTest {
         assertTrue(Email.isValid("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValid("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValid("e1234567@u.nus.edu")); // more than one period in domain
+        assertTrue(Email.isValid("cloud@my-domain.x")); // Short top level domain
     }
 }

--- a/src/test/java/swe/context/model/contact/PhoneTest.java
+++ b/src/test/java/swe/context/model/contact/PhoneTest.java
@@ -11,16 +11,15 @@ public class PhoneTest {
     @Test
     public void isValidPhone() {
         // invalid phone numbers
-        assertFalse(Phone.isValid("")); // empty string
-        assertFalse(Phone.isValid(" ")); // spaces only
-        assertFalse(Phone.isValid("91")); // less than 3 numbers
-        assertFalse(Phone.isValid("phone")); // non-numeric
-        assertFalse(Phone.isValid("9011p041")); // alphabets within digits
-        assertFalse(Phone.isValid("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValid(""));
+        assertFalse(Phone.isValid(" "));
+        assertFalse(Phone.isValid("91")); // Less than 3 digits
+        assertFalse(Phone.isValid("phone")); // Does not start with digits
 
         // valid phone numbers
-        assertTrue(Phone.isValid("911")); // exactly 3 numbers
+        assertTrue(Phone.isValid("911")); // Starts with 3 digits
         assertTrue(Phone.isValid("93121534"));
-        assertTrue(Phone.isValid("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValid("124293842033123")); // Long phone number
+        assertTrue(Phone.isValid("999 (police)")); // Phone number with added text
     }
 }

--- a/src/test/java/swe/context/storage/JsonContactTest.java
+++ b/src/test/java/swe/context/storage/JsonContactTest.java
@@ -38,7 +38,7 @@ public class JsonContactTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonContact contact =
                 new JsonContact(TestData.Invalid.NAME, VALID_PHONE, VALID_EMAIL, VALID_NOTE, VALID_TAGS);
-        String expectedMessage = Messages.NAME_CONSTRAINTS;
+        String expectedMessage = Messages.NAME_INVALID;
         assertThrows(IllegalValueException.class, expectedMessage, contact::toModelType);
     }
 
@@ -53,7 +53,7 @@ public class JsonContactTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonContact contact =
                 new JsonContact(VALID_NAME, TestData.Invalid.PHONE, VALID_EMAIL, VALID_NOTE, VALID_TAGS);
-        String expectedMessage = Messages.PHONE_CONSTRAINTS;
+        String expectedMessage = Messages.PHONE_INVALID;
         assertThrows(IllegalValueException.class, expectedMessage, contact::toModelType);
     }
 

--- a/src/test/java/swe/context/testutil/TestData.java
+++ b/src/test/java/swe/context/testutil/TestData.java
@@ -187,12 +187,12 @@ public final class TestData {
      * Holds invalid test data.
      */
     public static final class Invalid {
-        public static final String NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
-        public static final String PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
-        public static final String EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
         public static final String NAME = "R@chel";
+        public static final String NAME_DESC = " " + PREFIX_NAME + "James&";
         public static final String PHONE = "+651234";
+        public static final String PHONE_DESC = " " + PREFIX_PHONE + "99 (need 3+ digits)";
         public static final String EMAIL = "example.com";
+        public static final String EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo";
 
         /**
          * Holds tag-related data.


### PR DESCRIPTION
This PR relaxes some contact validation regexes to help avoid strict validation being considered a feature flaw. It makes relevant changes as needed.

Closes #97.