### PR TITLE
Make contact card have less empty space

### DIFF
--- a/src/main/java/swe/context/ui/ContactCard.java
+++ b/src/main/java/swe/context/ui/ContactCard.java
@@ -44,11 +44,20 @@ public class ContactCard extends UiPart<Region> {
         super(FXML);
         this.contact = contact;
 
-        id.setText(displayedIndex + ". ");
+        id.setText("#" + displayedIndex);
         name.setText(contact.getName().value);
         phone.setText(contact.getPhone().value);
         email.setText(contact.getEmail().value);
-        note.setText(contact.getNote().value);
+
+        String note = contact.getNote().value;
+        if (note != "") {
+            this.note.setVisible(true);
+            this.note.setManaged(true);
+            this.note.setText(contact.getNote().value);
+        } else {
+            this.note.setVisible(false);
+            this.note.setManaged(false);
+        }
 
         contact.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.value))

--- a/src/main/resources/view/ContactListCard.fxml
+++ b/src/main/resources/view/ContactListCard.fxml
@@ -14,7 +14,7 @@
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+    <VBox alignment="CENTER_LEFT" minHeight="50" GridPane.columnIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>


### PR DESCRIPTION
- Reduce min height of contact card so that "short" cards from contacts with little details aren't centred in a tall card with lots of empty space above/below
- Hide empty notes such that they don't take up a blank line and offset the card's position (akin to CSS `display: none`)
- Change index number format from `1. ` to `#1`

![image](https://github.com/AY2324S1-CS2103-W14-3/tp/assets/44526554/e4c109cf-a03e-4c11-b47f-945ef331895e)
