### PR TITLE
Increase output box, default window size

### DIFF
--- a/src/main/java/swe/context/commons/core/GuiSettings.java
+++ b/src/main/java/swe/context/commons/core/GuiSettings.java
@@ -11,8 +11,8 @@ import swe.context.commons.util.ToStringBuilder;
  * Immutably represents GUI settings.
  */
 public class GuiSettings {
-    private static final double DEFAULT_HEIGHT = 600;
-    private static final double DEFAULT_WIDTH = 740;
+    private static final double DEFAULT_HEIGHT = 650;
+    private static final double DEFAULT_WIDTH = 1250;
 
     private final double windowWidth;
     private final double windowHeight;

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -40,7 +40,7 @@
         </StackPane>
 
         <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
+                   minHeight="130" prefHeight="130" maxHeight="130">
           <padding>
             <Insets top="5" right="10" bottom="5" left="10" />
           </padding>


### PR DESCRIPTION
This PR increases the default window size while still accounting for the 1280x720 project constraint. This is mainly to make the width longer so that command output is easier to read.

It also increases the height of the output box (where command feedback is shown). It should now nicely fit 4 lines of output without needing scrolling.

![image](https://github.com/AY2324S1-CS2103-W14-3/tp/assets/44526554/4809376f-ce2b-49fc-a906-d7c8b738b6e6)

Closes #136.
