### PR TITLE
Enhance FileUtil, tests

### DIFF
--- a/src/main/java/swe/context/commons/util/FileUtil.java
+++ b/src/main/java/swe/context/commons/util/FileUtil.java
@@ -14,57 +14,26 @@ import java.nio.file.Paths;
 public class FileUtil {
     private static final String CHARSET = "UTF-8";
 
-    public static boolean isFileExists(Path file) {
-        return Files.exists(file) && Files.isRegularFile(file);
-    }
-
     /**
-     * Assumes file exists
+     * Assumes file exists.
      */
     public static String readFromFile(Path file) throws IOException {
         return new String(Files.readAllBytes(file), CHARSET);
     }
 
     /**
-     * Writes given string to a file.
-     * Will create the file if it does not exist yet.
+     * Writes the specified string content to the specified file path.
+     *
+     * Will create the parent folders/file if they do not exist yet.
      */
-    public static void writeToFile(Path file, String content) throws IOException {
-        Files.write(file, content.getBytes(CHARSET));
-    }
+    public static void writeToFile(Path path, String content) throws IOException {
+        // File file = path.toFile();
+        // @Nullable File parentFolder = file.getParentFile();
+        // if (parentFolder != null) {
+        //     parentFolder.mkdirs();
+        // }
 
-    /**
-     * Creates a file if it does not exist along with its missing parent directories.
-     * @throws IOException if the file or directory cannot be created.
-     */
-    public static void createIfMissing(Path file) throws IOException {
-        if (!isFileExists(file)) {
-            createFile(file);
-        }
-    }
-
-    /**
-     * Creates a file if it does not exist along with its missing parent directories.
-     */
-    public static void createFile(Path file) throws IOException {
-        if (Files.exists(file)) {
-            return;
-        }
-
-        createParentDirsOfFile(file);
-
-        Files.createFile(file);
-    }
-
-    /**
-     * Creates parent directories of file if it has a parent directory
-     */
-    public static void createParentDirsOfFile(Path file) throws IOException {
-        Path parentDir = file.getParent();
-
-        if (parentDir != null) {
-            Files.createDirectories(parentDir);
-        }
+        Files.write(path, content.getBytes(CHARSET));
     }
 
     /**

--- a/src/main/java/swe/context/commons/util/FileUtil.java
+++ b/src/main/java/swe/context/commons/util/FileUtil.java
@@ -1,10 +1,13 @@
 package swe.context.commons.util;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import swe.context.annotation.Nullable;
 
 
 
@@ -27,11 +30,11 @@ public class FileUtil {
      * Will create the parent folders/file if they do not exist yet.
      */
     public static void writeToFile(Path path, String content) throws IOException {
-        // File file = path.toFile();
-        // @Nullable File parentFolder = file.getParentFile();
-        // if (parentFolder != null) {
-        //     parentFolder.mkdirs();
-        // }
+        File file = path.toFile();
+        @Nullable File parentFolder = file.getParentFile();
+        if (parentFolder != null) {
+            parentFolder.mkdirs();
+        }
 
         Files.write(path, content.getBytes(CHARSET));
     }

--- a/src/main/java/swe/context/storage/JsonContactsStorage.java
+++ b/src/main/java/swe/context/storage/JsonContactsStorage.java
@@ -8,7 +8,6 @@ import java.util.logging.Logger;
 import swe.context.commons.core.LogsCenter;
 import swe.context.commons.exceptions.DataLoadingException;
 import swe.context.commons.exceptions.IllegalValueException;
-import swe.context.commons.util.FileUtil;
 import swe.context.commons.util.JsonUtil;
 import swe.context.commons.util.StringUtil;
 import swe.context.model.Contacts;
@@ -64,7 +63,6 @@ public class JsonContactsStorage implements ContactsStorage {
 
     @Override
     public void saveContacts(ReadOnlyContacts contacts) throws IOException {
-        FileUtil.createIfMissing(path);
         JsonUtil.saveJsonFile(new JsonContacts(contacts), this.path);
     }
 }

--- a/src/test/java/swe/context/commons/util/FileUtilTest.java
+++ b/src/test/java/swe/context/commons/util/FileUtilTest.java
@@ -2,14 +2,12 @@ package swe.context.commons.util;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static swe.context.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 
 
 public class FileUtilTest {
-
     @Test
     public void isValidPath() {
         // valid path
@@ -17,9 +15,5 @@ public class FileUtilTest {
 
         // invalid path
         assertFalse(FileUtil.isValidPath("a\0"));
-
-        // null path -> throws NullPointerException
-        assertThrows(NullPointerException.class, () -> FileUtil.isValidPath(null));
     }
-
 }

--- a/src/test/java/swe/context/commons/util/JsonUtilTest.java
+++ b/src/test/java/swe/context/commons/util/JsonUtilTest.java
@@ -29,7 +29,7 @@ public class JsonUtilTest {
     public static Path tempDir;
 
     private Path getSerializationPath() {
-        return JsonUtilTest.tempDir.resolve("serialization.json");
+        return JsonUtilTest.tempDir.resolve("folder/serialization.json");
     }
 
     @Test


### PR DESCRIPTION
This PR simplifies the creation of parent folders in FileUtil and makes it take place at a lower level. It updates some of the Javadocs.

It also modifies the JsonUtilTest to have a parent folder, as a convenient way to have our test suite confirm that this works (as opposed to writing up more FileUtilTest with a tempdir).

It does not touch the error message that may eventually propagate up to `fileOpsErrorFormat()`, as seen in #116.

Closes #122.
