### PR TITLE
Fix note comparison when deciding visibility

### DIFF
--- a/src/main/java/swe/context/ui/ContactCard.java
+++ b/src/main/java/swe/context/ui/ContactCard.java
@@ -50,7 +50,7 @@ public class ContactCard extends UiPart<Region> {
         email.setText(contact.getEmail().value);
 
         String note = contact.getNote().value;
-        if (note != "") {
+        if (!note.equals("")) {
             this.note.setVisible(true);
             this.note.setManaged(true);
             this.note.setText(contact.getNote().value);


### PR DESCRIPTION
There is a bug in the string comparison for note done in `ContactCard`, since it uses `==`. When the application first launches, the initial UI looks fine, maybe something about Java's string pool causing the reference equality to be true. But later on, when adding/editing with empty notes, they fail the comparison and thus end up visible as empty notes, taking up a line of space.

This PR fixes this bug.

See also #150.
