### PR TITLE
Relevant changes to address duplicate indices in deleteCommand

### DIFF
--- a/src/main/java/swe/context/logic/Messages.java
+++ b/src/main/java/swe/context/logic/Messages.java
@@ -20,6 +20,8 @@ public final class Messages {
     private static final String UNFORMATTED_CONTACTS_LISTED_OVERVIEW = "%d contacts listed.";
     private static final String UNFORMATTED_ADD_COMMAND_SUCCESS = "New contact added: %s";
     private static final String UNFORMATTED_DELETE_COMMAND_SUCCESS = "Deleted contact(s):%n%s";
+    private static final String UNFORMATTED_DELETE_DUPLICATE_COMMAND_SUCCESS =
+            "Note that the duplicate indices just provided only count once.\n Deleted contact(s):%n%s";
     private static final String UNFORMATTED_EDIT_COMMAND_SUCCESS = "Edited contact: %s";
 
     // Specific commands
@@ -117,6 +119,13 @@ public final class Messages {
      */
     public static String editCommandSuccess(String contactDetails) {
         return String.format(UNFORMATTED_EDIT_COMMAND_SUCCESS, contactDetails);
+    }
+
+    /**
+     * Returns a formatted message indicating successful deletion that contains duplicate.
+     */
+    public static String deleteDuplicateCommandSuccess(String contactDetails) {
+        return String.format(UNFORMATTED_DELETE_DUPLICATE_COMMAND_SUCCESS, contactDetails);
     }
 
     /**

--- a/src/main/java/swe/context/logic/Messages.java
+++ b/src/main/java/swe/context/logic/Messages.java
@@ -21,7 +21,7 @@ public final class Messages {
     private static final String UNFORMATTED_ADD_COMMAND_SUCCESS = "New contact added: %s";
     private static final String UNFORMATTED_DELETE_COMMAND_SUCCESS = "Deleted contact(s):%n%s";
     private static final String UNFORMATTED_DELETE_DUPLICATE_COMMAND_SUCCESS =
-            "Note that the duplicate indices just provided only count once.\n Deleted contact(s):%n%s";
+            "Note that the duplicate indices just provided only count once.\nDeleted contact(s):%n%s";
     private static final String UNFORMATTED_EDIT_COMMAND_SUCCESS = "Edited contact: %s";
 
     // Specific commands

--- a/src/main/java/swe/context/logic/commands/DeleteCommand.java
+++ b/src/main/java/swe/context/logic/commands/DeleteCommand.java
@@ -33,6 +33,12 @@ public class DeleteCommand extends Command {
     private final List<Index> targetIndices;
     private final boolean hasDuplicate;
 
+    /**
+     * Constructs a new {@code DeleteCommand} with the specified indices and duplication status.
+     *
+     * @param targetIndices the list of indices of the items to be deleted.
+     * @param hasDuplicate a boolean value indicating if there are duplicate indices in the list.
+     */
     public DeleteCommand(List<Index> targetIndices, boolean hasDuplicate) {
         this.targetIndices = targetIndices;
         this.hasDuplicate = hasDuplicate;

--- a/src/main/java/swe/context/logic/commands/DeleteCommand.java
+++ b/src/main/java/swe/context/logic/commands/DeleteCommand.java
@@ -31,9 +31,11 @@ public class DeleteCommand extends Command {
     );
 
     private final List<Index> targetIndices;
+    private final boolean hasDuplicate;
 
-    public DeleteCommand(List<Index> targetIndices) {
+    public DeleteCommand(List<Index> targetIndices, boolean hasDuplicate) {
         this.targetIndices = targetIndices;
+        this.hasDuplicate = hasDuplicate;
     }
 
     @Override
@@ -43,7 +45,7 @@ public class DeleteCommand extends Command {
         List<Contact> contactsToDelete = new ArrayList<>();
 
         // Collect contacts to delete
-        for (int i = 0; i < targetIndices.size() - 1; i++) {
+        for (int i = 0; i < targetIndices.size(); i++) {
             Index index = targetIndices.get(i);
             if (index.getZeroBased() >= currentContactList.size()) {
                 throw new CommandException(Messages.INVALID_DELETE_INDEX);
@@ -61,7 +63,7 @@ public class DeleteCommand extends Command {
                 .map(Contact::format)
                 .collect(Collectors.joining(",\n"));
 
-        if (targetIndices.get(targetIndices.size() - 1).getZeroBased() == 1) {
+        if (hasDuplicate) {
             return new CommandResult(Messages.deleteDuplicateCommandSuccess(formattedContacts));
         }
         return new CommandResult(Messages.deleteCommandSuccess(formattedContacts));
@@ -76,7 +78,8 @@ public class DeleteCommand extends Command {
             return false;
         }
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndices.equals(otherDeleteCommand.targetIndices);
+        return targetIndices.equals(otherDeleteCommand.targetIndices)
+                && this.hasDuplicate == otherDeleteCommand.hasDuplicate;
     }
 
     @Override

--- a/src/main/java/swe/context/logic/commands/DeleteCommand.java
+++ b/src/main/java/swe/context/logic/commands/DeleteCommand.java
@@ -43,7 +43,8 @@ public class DeleteCommand extends Command {
         List<Contact> contactsToDelete = new ArrayList<>();
 
         // Collect contacts to delete
-        for (Index index : targetIndices) {
+        for (int i = 0; i < targetIndices.size() - 1; i++) {
+            Index index = targetIndices.get(i);
             if (index.getZeroBased() >= currentContactList.size()) {
                 throw new CommandException(Messages.INVALID_DELETE_INDEX);
             }
@@ -60,6 +61,9 @@ public class DeleteCommand extends Command {
                 .map(Contact::format)
                 .collect(Collectors.joining(",\n"));
 
+        if (targetIndices.get(targetIndices.size() - 1).getZeroBased() == 1) {
+            return new CommandResult(Messages.deleteDuplicateCommandSuccess(formattedContacts));
+        }
         return new CommandResult(Messages.deleteCommandSuccess(formattedContacts));
     }
 

--- a/src/main/java/swe/context/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/swe/context/logic/parser/DeleteCommandParser.java
@@ -22,13 +22,22 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         try {
             String[] splitArgs = args.trim().split("\\s+");
             List<Index> indices = new ArrayList<>();
+            boolean hasDuplicate = false;
 
             // Parse all the index arguments and add to the list if it doesn't already contain it
             for (String arg : splitArgs) {
                 Index currentIndex = ParserUtil.parseIndex(arg);
-                if (!indices.contains(currentIndex)) {
-                    indices.add(currentIndex);
+                if (indices.contains(currentIndex)) {
+                    hasDuplicate = true;
+                    continue;
                 }
+                indices.add(currentIndex);
+            }
+
+            if (hasDuplicate) {
+                indices.add(Index.fromZeroBased(1));
+            } else {
+                indices.add(Index.fromZeroBased(0));
             }
 
             return new DeleteCommand(indices);

--- a/src/main/java/swe/context/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/swe/context/logic/parser/DeleteCommandParser.java
@@ -34,13 +34,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                 indices.add(currentIndex);
             }
 
-            if (hasDuplicate) {
-                indices.add(Index.fromZeroBased(1));
-            } else {
-                indices.add(Index.fromZeroBased(0));
-            }
-
-            return new DeleteCommand(indices);
+            return new DeleteCommand(indices, hasDuplicate);
 
         } catch (ParseException e) {
             throw new ParseException(

--- a/src/test/java/swe/context/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/swe/context/logic/commands/DeleteCommandTest.java
@@ -143,7 +143,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_validIndicesUnfilteredList_success_hasDuplicate() {
+    public void execute_validIndicesUnfilteredList_success_has_duplicate() {
         Contact firstContactToDelete =
                 model.getFilteredContactList().get(TestData.IndexContact.FIRST_CONTACT.getZeroBased());
         Contact secondContactToDelete =

--- a/src/test/java/swe/context/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/swe/context/logic/commands/DeleteCommandTest.java
@@ -31,7 +31,8 @@ public class DeleteCommandTest {
     public void execute_validIndexUnfilteredList_success() {
         Contact contactToDelete =
                 model.getFilteredContactList().get(TestData.IndexContact.FIRST_CONTACT.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT));
+        DeleteCommand deleteCommand =
+                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT, Index.fromZeroBased(0)));
 
         String expectedMessage = Messages.deleteCommandSuccess(Contact.format(contactToDelete));
 
@@ -44,7 +45,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredContactList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex));
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex, Index.fromZeroBased(0)));
 
         assertCommandFailure(deleteCommand, model, Messages.INVALID_DELETE_INDEX);
     }
@@ -54,7 +55,8 @@ public class DeleteCommandTest {
         showContactAtIndex(model, TestData.IndexContact.FIRST_CONTACT);
         Contact contactToDelete =
                 model.getFilteredContactList().get(TestData.IndexContact.FIRST_CONTACT.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT));
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT,
+                Index.fromZeroBased(0)));
 
         String expectedMessage = Messages.deleteCommandSuccess(Contact.format(contactToDelete));
 
@@ -73,7 +75,7 @@ public class DeleteCommandTest {
         // Before removal, ensure the index is still in the bounds of contact list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getContacts().getUnmodifiableList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex));
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex, Index.fromZeroBased(0)));
 
         assertCommandFailure(deleteCommand, model, Messages.INVALID_DELETE_INDEX);
     }
@@ -128,9 +130,29 @@ public class DeleteCommandTest {
                 model.getFilteredContactList().get(TestData.IndexContact.SECOND_CONTACT.getZeroBased());
         DeleteCommand deleteCommand =
                 new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT,
-                        TestData.IndexContact.SECOND_CONTACT));
+                        TestData.IndexContact.SECOND_CONTACT, Index.fromZeroBased(0)));
 
         String expectedMessage = Messages.deleteCommandSuccess(
+                Contact.format(firstContactToDelete) + ",\n" + Contact.format(secondContactToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getContacts(), new Settings());
+        expectedModel.removeContact(firstContactToDelete);
+        expectedModel.removeContact(secondContactToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndicesUnfilteredList_success_hasDuplicate() {
+        Contact firstContactToDelete =
+                model.getFilteredContactList().get(TestData.IndexContact.FIRST_CONTACT.getZeroBased());
+        Contact secondContactToDelete =
+                model.getFilteredContactList().get(TestData.IndexContact.SECOND_CONTACT.getZeroBased());
+        DeleteCommand deleteCommand =
+                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT,
+                        TestData.IndexContact.SECOND_CONTACT, Index.fromZeroBased(1)));
+
+        String expectedMessage = Messages.deleteDuplicateCommandSuccess(
                 Contact.format(firstContactToDelete) + ",\n" + Contact.format(secondContactToDelete));
 
         ModelManager expectedModel = new ModelManager(model.getContacts(), new Settings());
@@ -149,7 +171,8 @@ public class DeleteCommandTest {
 
         // Providing the SECOND_CONTACT before the FIRST_CONTACT in the list.
         List<Index> unorderedIndices =
-                List.of(TestData.IndexContact.SECOND_CONTACT, TestData.IndexContact.FIRST_CONTACT);
+                List.of(TestData.IndexContact.SECOND_CONTACT,
+                        TestData.IndexContact.FIRST_CONTACT, Index.fromZeroBased(0));
         DeleteCommand deleteCommand = new DeleteCommand(unorderedIndices);
 
         String expectedMessage = Messages.deleteCommandSuccess(
@@ -168,7 +191,7 @@ public class DeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredContactList().size() + 1);
 
         // Providing a valid index followed by an invalid one.
-        List<Index> indices = List.of(validIndex, outOfBoundIndex);
+        List<Index> indices = List.of(validIndex, outOfBoundIndex, Index.fromZeroBased(0));
         DeleteCommand deleteCommand = new DeleteCommand(indices);
 
         assertCommandFailure(deleteCommand, model, Messages.INVALID_DELETE_INDEX);

--- a/src/test/java/swe/context/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/swe/context/logic/commands/DeleteCommandTest.java
@@ -143,7 +143,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_validIndicesUnfilteredList_success_has_duplicate() {
+    public void execute_validIndicesUnfilteredList_successWithDuplicate() {
         Contact firstContactToDelete =
                 model.getFilteredContactList().get(TestData.IndexContact.FIRST_CONTACT.getZeroBased());
         Contact secondContactToDelete =

--- a/src/test/java/swe/context/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/swe/context/logic/commands/DeleteCommandTest.java
@@ -32,7 +32,7 @@ public class DeleteCommandTest {
         Contact contactToDelete =
                 model.getFilteredContactList().get(TestData.IndexContact.FIRST_CONTACT.getZeroBased());
         DeleteCommand deleteCommand =
-                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT, Index.fromZeroBased(0)));
+                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT), false);
 
         String expectedMessage = Messages.deleteCommandSuccess(Contact.format(contactToDelete));
 
@@ -45,7 +45,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredContactList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex, Index.fromZeroBased(0)));
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex), false);
 
         assertCommandFailure(deleteCommand, model, Messages.INVALID_DELETE_INDEX);
     }
@@ -55,8 +55,7 @@ public class DeleteCommandTest {
         showContactAtIndex(model, TestData.IndexContact.FIRST_CONTACT);
         Contact contactToDelete =
                 model.getFilteredContactList().get(TestData.IndexContact.FIRST_CONTACT.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT,
-                Index.fromZeroBased(0)));
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT), false);
 
         String expectedMessage = Messages.deleteCommandSuccess(Contact.format(contactToDelete));
 
@@ -75,24 +74,23 @@ public class DeleteCommandTest {
         // Before removal, ensure the index is still in the bounds of contact list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getContacts().getUnmodifiableList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex, Index.fromZeroBased(0)));
-
+        DeleteCommand deleteCommand = new DeleteCommand(List.of(outOfBoundIndex), false);
         assertCommandFailure(deleteCommand, model, Messages.INVALID_DELETE_INDEX);
     }
 
     @Test
     public void equals() {
         DeleteCommand deleteFirstCommand =
-                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT));
+                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT), false);
         DeleteCommand deleteSecondCommand =
-                new DeleteCommand(List.of(TestData.IndexContact.SECOND_CONTACT));
+                new DeleteCommand(List.of(TestData.IndexContact.SECOND_CONTACT), false);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
         DeleteCommand deleteFirstCommandCopy =
-                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT));
+                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT), false);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -108,7 +106,7 @@ public class DeleteCommandTest {
     @Test
     public void toStringMethod() {
         List<Index> targetIndices = List.of(Index.fromOneBased(1), Index.fromOneBased(2));
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndices);
+        DeleteCommand deleteCommand = new DeleteCommand(targetIndices, true);
         String expected = DeleteCommand.class.getCanonicalName() + "{targetIndices=" + targetIndices + "}";
         assertEquals(expected, deleteCommand.toString());
     }
@@ -130,7 +128,7 @@ public class DeleteCommandTest {
                 model.getFilteredContactList().get(TestData.IndexContact.SECOND_CONTACT.getZeroBased());
         DeleteCommand deleteCommand =
                 new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT,
-                        TestData.IndexContact.SECOND_CONTACT, Index.fromZeroBased(0)));
+                        TestData.IndexContact.SECOND_CONTACT), false);
 
         String expectedMessage = Messages.deleteCommandSuccess(
                 Contact.format(firstContactToDelete) + ",\n" + Contact.format(secondContactToDelete));
@@ -150,7 +148,7 @@ public class DeleteCommandTest {
                 model.getFilteredContactList().get(TestData.IndexContact.SECOND_CONTACT.getZeroBased());
         DeleteCommand deleteCommand =
                 new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT,
-                        TestData.IndexContact.SECOND_CONTACT, Index.fromZeroBased(1)));
+                        TestData.IndexContact.SECOND_CONTACT), true);
 
         String expectedMessage = Messages.deleteDuplicateCommandSuccess(
                 Contact.format(firstContactToDelete) + ",\n" + Contact.format(secondContactToDelete));
@@ -172,8 +170,8 @@ public class DeleteCommandTest {
         // Providing the SECOND_CONTACT before the FIRST_CONTACT in the list.
         List<Index> unorderedIndices =
                 List.of(TestData.IndexContact.SECOND_CONTACT,
-                        TestData.IndexContact.FIRST_CONTACT, Index.fromZeroBased(0));
-        DeleteCommand deleteCommand = new DeleteCommand(unorderedIndices);
+                        TestData.IndexContact.FIRST_CONTACT);
+        DeleteCommand deleteCommand = new DeleteCommand(unorderedIndices, false);
 
         String expectedMessage = Messages.deleteCommandSuccess(
                 Contact.format(secondContactToDelete) + ",\n" + Contact.format(firstContactToDelete));
@@ -191,8 +189,8 @@ public class DeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredContactList().size() + 1);
 
         // Providing a valid index followed by an invalid one.
-        List<Index> indices = List.of(validIndex, outOfBoundIndex, Index.fromZeroBased(0));
-        DeleteCommand deleteCommand = new DeleteCommand(indices);
+        List<Index> indices = List.of(validIndex, outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(indices, false);
 
         assertCommandFailure(deleteCommand, model, Messages.INVALID_DELETE_INDEX);
     }

--- a/src/test/java/swe/context/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/swe/context/logic/parser/DeleteCommandParserTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import swe.context.commons.core.index.Index;
 import swe.context.logic.Messages;
 import swe.context.logic.commands.DeleteCommand;
 import swe.context.testutil.TestData;
@@ -23,8 +24,15 @@ public class DeleteCommandParserTest {
     private DeleteCommandParser parser = new DeleteCommandParser();
 
     @Test
-    public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT)));
+    public void parse_validArgs_returnsDeleteCommand1() {
+        assertParseSuccess(parser, "1",
+                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT, Index.fromZeroBased(0))));
+    }
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand2() {
+        assertParseSuccess(parser, "1 1",
+                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT, Index.fromZeroBased(1))));
     }
 
     @Test

--- a/src/test/java/swe/context/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/swe/context/logic/parser/DeleteCommandParserTest.java
@@ -26,13 +26,13 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_validArgs_returnsDeleteCommand1() {
         assertParseSuccess(parser, "1",
-                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT, Index.fromZeroBased(0))));
+                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT), false));
     }
 
     @Test
     public void parse_validArgs_returnsDeleteCommand2() {
         assertParseSuccess(parser, "1 1",
-                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT, Index.fromZeroBased(1))));
+                new DeleteCommand(List.of(TestData.IndexContact.FIRST_CONTACT), true));
     }
 
     @Test

--- a/src/test/java/swe/context/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/swe/context/logic/parser/DeleteCommandParserTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import swe.context.commons.core.index.Index;
 import swe.context.logic.Messages;
 import swe.context.logic.commands.DeleteCommand;
 import swe.context.testutil.TestData;

--- a/src/test/java/swe/context/logic/parser/InputParserTest.java
+++ b/src/test/java/swe/context/logic/parser/InputParserTest.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import swe.context.commons.core.index.Index;
 import swe.context.logic.Messages;
 import swe.context.logic.commands.AddCommand;
 import swe.context.logic.commands.ClearCommand;

--- a/src/test/java/swe/context/logic/parser/InputParserTest.java
+++ b/src/test/java/swe/context/logic/parser/InputParserTest.java
@@ -52,7 +52,7 @@ public class InputParserTest {
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) InputParser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + FIRST_CONTACT.getOneBased());
-        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT, Index.fromZeroBased(0))), command);
+        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT), false), command);
     }
 
     @Test
@@ -60,8 +60,8 @@ public class InputParserTest {
         DeleteCommand command = (DeleteCommand) InputParser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + FIRST_CONTACT.getOneBased()
                 + " " + SECOND_CONTACT.getOneBased());
-        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT, SECOND_CONTACT,
-                Index.fromZeroBased(0))), command);
+        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT, SECOND_CONTACT),
+                false), command);
     }
 
     @Test
@@ -70,7 +70,7 @@ public class InputParserTest {
                 DeleteCommand.COMMAND_WORD + " " + FIRST_CONTACT.getOneBased()
                 + " " + FIRST_CONTACT.getOneBased()
                 + " " + FIRST_CONTACT.getOneBased());
-        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT, Index.fromZeroBased(1))), command);
+        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT), true), command);
     }
 
     @Test

--- a/src/test/java/swe/context/logic/parser/InputParserTest.java
+++ b/src/test/java/swe/context/logic/parser/InputParserTest.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import swe.context.commons.core.index.Index;
 import swe.context.logic.Messages;
 import swe.context.logic.commands.AddCommand;
 import swe.context.logic.commands.ClearCommand;
@@ -51,7 +52,7 @@ public class InputParserTest {
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) InputParser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + FIRST_CONTACT.getOneBased());
-        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT)), command);
+        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT, Index.fromZeroBased(0))), command);
     }
 
     @Test
@@ -59,7 +60,7 @@ public class InputParserTest {
         DeleteCommand command = (DeleteCommand) InputParser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + FIRST_CONTACT.getOneBased()
                 + " " + SECOND_CONTACT.getOneBased());
-        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT, SECOND_CONTACT)), command);
+        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT, SECOND_CONTACT,  Index.fromZeroBased(0))), command);
     }
 
     @Test
@@ -68,7 +69,7 @@ public class InputParserTest {
                 DeleteCommand.COMMAND_WORD + " " + FIRST_CONTACT.getOneBased()
                 + " " + FIRST_CONTACT.getOneBased()
                 + " " + FIRST_CONTACT.getOneBased());
-        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT)), command);
+        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT,  Index.fromZeroBased(1))), command);
     }
 
     @Test

--- a/src/test/java/swe/context/logic/parser/InputParserTest.java
+++ b/src/test/java/swe/context/logic/parser/InputParserTest.java
@@ -70,7 +70,7 @@ public class InputParserTest {
                 DeleteCommand.COMMAND_WORD + " " + FIRST_CONTACT.getOneBased()
                 + " " + FIRST_CONTACT.getOneBased()
                 + " " + FIRST_CONTACT.getOneBased());
-        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT,  Index.fromZeroBased(1))), command);
+        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT, Index.fromZeroBased(1))), command);
     }
 
     @Test

--- a/src/test/java/swe/context/logic/parser/InputParserTest.java
+++ b/src/test/java/swe/context/logic/parser/InputParserTest.java
@@ -60,7 +60,8 @@ public class InputParserTest {
         DeleteCommand command = (DeleteCommand) InputParser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + FIRST_CONTACT.getOneBased()
                 + " " + SECOND_CONTACT.getOneBased());
-        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT, SECOND_CONTACT,  Index.fromZeroBased(0))), command);
+        assertEquals(new DeleteCommand(List.of(FIRST_CONTACT, SECOND_CONTACT,
+                Index.fromZeroBased(0))), command);
     }
 
     @Test


### PR DESCRIPTION
Address the issue where duplicate indices get silently merged. Now the message will contain an extra line "Note that the duplicate indices just provided only count once." to notify the user.

Solution: add a dummy index to the end of the parsed indices. If there is duplicate, the dummy index is 1, otherwise 0. Based on the index, deleteCommand will decide whether the extra message will be displayed.
